### PR TITLE
Release: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,8 @@ All notable changes to this project will be documented in this file. See [standa
 ## [1.0.0] 2023-08-05
 
 Very first initial stable release. 🎉
+
+## [1.0.1] 2023-09-05
+
+- `inputStyle`, `wrapperClassName` and `wrapperStyle` is working now.
+- Removing `className` and `style` props to prevent clash with input and wrapper className and style.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "antd-input-otp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An OTP Input Component based on Ant Design Component Library for React.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.es.js",
   "scripts": {
     "build": "rollup -c",
+    "patch": "npm version patch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/src/lib/InputOTP.component.tsx
+++ b/src/lib/InputOTP.component.tsx
@@ -20,15 +20,17 @@ const InputOTPSingle: React.FC<InputProps> = ({ className, ...rest }) => {
 const InputOTP = forwardRef<HTMLDivElement, InputOTPProps>(
   (
     {
-      className,
       disabled,
       inputClassName,
-      length = 6,
-      placeholder,
-      onChange,
       inputRegex,
+      inputStyle,
       inputType = "all",
+      length = 6,
+      onChange,
+      placeholder,
       value,
+      wrapperClassName,
+      wrapperStyle,
       ...rest
     },
     ref
@@ -48,7 +50,11 @@ const InputOTP = forwardRef<HTMLDivElement, InputOTPProps>(
     }, [length]);
 
     return (
-      <div className={cx("input-otp", className)} ref={ref}>
+      <div
+        className={cx("input-otp", wrapperClassName)}
+        ref={ref}
+        style={wrapperStyle}
+      >
         {Array(makeLength)
           .fill(null)
           .map((_, idx) => (
@@ -62,6 +68,7 @@ const InputOTP = forwardRef<HTMLDivElement, InputOTPProps>(
               onKeyDown={handleKeyDown}
               onKeyPress={handleKeyPress}
               className={inputClassName}
+              style={inputStyle}
               disabled={disabled}
               placeholder={
                 placeholder?.length === 1 ? placeholder : placeholder?.[idx]

--- a/src/lib/InputOTP.types.ts
+++ b/src/lib/InputOTP.types.ts
@@ -1,6 +1,7 @@
 import type { InputProps } from "antd";
 
-interface BaseInputOTPProps extends Omit<InputProps, "value" | "onChange"> {
+interface BaseInputOTPProps
+  extends Omit<InputProps, "value" | "onChange" | "className" | "style"> {
   disabled?: boolean;
   /** Classes for styling input field. */
   inputClassName?: InputProps["className"];


### PR DESCRIPTION
# Changes [1.0.1 - STABLE]:
- `inputStyle`, `wrapperClassName` and `wrapperStyle` is working now.
- Removing `className` and `style` props to prevent clash with input and wrapper className and style.