### PR TITLE
bugfix: ES Module Not Found on Create React App

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,9 @@
     "@rollup/plugin-typescript": "^11.1.0",
     "@types/node": "^20.1.0",
     "@types/react": "^18.2.6",
-    "antd": "^5.4.7",
+    "antd": "^5.5.0",
     "classnames": "^2.3.2",
     "postcss": "^8.4.23",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "rollup": "^2.79.1",
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -45,7 +43,8 @@
   },
   "peerDependencies": {
     "antd": ">=4.19.0",
-    "react": ">=16.0.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,6 @@ export default [
       {
         file: "dist/esm/index.es.js",
         format: "es",
-        exports: "named",
         sourcemap: true,
       },
     ],


### PR DESCRIPTION
# Changes:
- Remove React and React DOM from Dev Deps 
- Update React and React DOM version on Peer Deps
- Update Antd Version on Dev Deps
- Remove named export on ES Module roll up config